### PR TITLE
fix metadata (add name)

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -1,3 +1,4 @@
+name             "celery"
 maintainer       "Needle Inc."
 maintainer_email "cookbooks@needle.com"
 license          "Apache 2.0"


### PR DESCRIPTION
I try to use the cookbook with [berkshelf](http://berkshelf.com/).
I added a below setting to`Berksfile` and try to execute `berks install`, and got a error.

```
cookbook 'celery', git: 'git@github.com:needle-cookbooks/chef-celery.git'
```

```
Fetching 'celery' from git@github.com:needle-cookbooks/chef-celery.git (at master)
The following error occurred while reading the cookbook `celery':
Ridley::Errors::MissingNameAttribute: The metadata at '/var/folders/90/bdn2dr8d0zn1jsbcbw21msz40000gp/T/d20150326-78074-1fvvbz4' does not contain a 'name' attribute. While Chef does not strictly enforce this requirement, Ridley cannot continue without a valid metadata 'name' entry.
```

`metadata.rb` must have `name` field, so I add the sentence into `metadata.rb`
